### PR TITLE
applyToElement() now uses correct methods for fetching matrix css

### DIFF
--- a/src/matrix.js
+++ b/src/matrix.js
@@ -813,7 +813,7 @@ Matrix.prototype = {
 	applyToElement: function(element, use3D) {
 		var me = this;
 		if (!me._px) me._px = me._getPX();
-		element.style[me._px] = use3D ? me.getCSS3D() : me.getCSS();
+		element.style[me._px] = use3D ? me.toCSS3D() : me.toCSS();
 		return me
 	},
 


### PR DESCRIPTION
When trying to use applyToElement() I noticed it used methods getCSS() and getCSS3D(), both of which threw an error because they didn't exist. I changed it to call toCSS() and toCSS3D() respectively.